### PR TITLE
Add kubernetes-intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # AlexInnRu_platform
 AlexInnRu Platform repository
+
+1.Создан dockerfile контейнера web
+2. Создан минимальный конфиг запуска nginx.conf
+3. Собран образ из dockerfile и выложен на Docker Hub
+   docker build -t alexinnru/otus_k8s:centos_nginx
+   docker push alexinnru/otus_k8s:centos_nginx
+4. Создан манифест web-pod.yaml и развернут под.
+   kubectl apply -f web-pod.yaml
+5. В манифест web-pod.yaml добавлен контейнер init и прописаны volumes
+6. Создан образ сервиса frontend
+   docker build -t alexinnru/otus_k8s:frontend -f ~/demo/microservices-demo/src/frontend/Dockerfile .
+7. Выложен образ сервиса в Docker Hub 
+   docker push alexinnru/otus_k8s:frontend
+8. Диагностика пода frontend 
+   kubectl logs frontend
+   {"message":"Tracing disabled.","severity":"info","timestamp":"2023-07-17T18:09:36.44627712Z"}
+{"message":"Profiling disabled.","severity":"info","timestamp":"2023-07-17T18:09:36.446482071Z"}
+panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
+
+goroutine 1 [running]:
+main.mustMapEnv(0xc000114480, {0xc0758d, 0x1c})
+        /src/main.go:208 +0xb9
+main.main()
+        /src/main.go:124 +0x5be
+9. Создаем новый манифест с указанием всех переменных frontend-pod-healthy.yaml
+10. Запускаем новый под из этого манифеста
+    kubectl apply -f frontend-pod-healthy.yaml
+   
+   

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,123 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      serviceAccountName: default
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+          image: alexinnru/otus_k8s:frontend
+          ports:
+          - containerPort: 8080
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+              - name: "Cookie"
+                value: "shop_session-id=x-readiness-probe"
+          livenessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+              - name: "Cookie"
+                value: "shop_session-id=x-liveness-probe"
+          env:
+          - name: PORT
+            value: "8080"
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: "productcatalogservice:3550"
+          - name: CURRENCY_SERVICE_ADDR
+            value: "currencyservice:7000"
+          - name: CART_SERVICE_ADDR
+            value: "cartservice:7070"
+          - name: RECOMMENDATION_SERVICE_ADDR
+            value: "recommendationservice:8080"
+          - name: SHIPPING_SERVICE_ADDR
+            value: "shippingservice:50051"
+          - name: CHECKOUT_SERVICE_ADDR
+            value: "checkoutservice:5050"
+          - name: AD_SERVICE_ADDR
+            value: "adservice:9555"
+          # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+          # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
+          # - name: ENV_PLATFORM
+          #   value: "aws"
+          - name: ENABLE_PROFILER
+            value: "0"
+          # - name: CYMBAL_BRANDING
+          #   value: "true"
+          # - name: FRONTEND_MESSAGE
+          #   value: "Replace this with a message you want to display on all pages."
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: alexinnru/otus_k8s:frontend
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    image: alexinnru/otus_k8s:centos_nginx
+    volumeMounts:
+    - mountPath: /app
+      name: app      
+  - name: init-web
+    image: busybox:1.31.0
+    volumeMounts:
+    - mountPath: /app
+      name: app      
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:centos7
+RUN mkdir/app/
+RUN yum -y install epel-release
+RUN yum -y install nginx
+RUN usermod -u 1001 nginx && groupmod -g 1001 nginx
+ADD nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8000
+CMD["nginx","-g","daemon off;"]

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,13 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+events {}
+
+http { 
+    server {
+        listen       8000;    
+       
+       }
+    }


### PR DESCRIPTION
Разберитесь почему все pod в namespace kube-system восстановились после удаления. Укажите причину в описании PR.

Поды восстановились т.к. сработал механизм самолечения. В частности:
под core-dns управляется ReplicaSet-Controller через kind ReplicaSet в котором задано необходимое кол-во подов в статусе Running
kube-apiserver управляется непосредственно minikube  Node/minikube